### PR TITLE
Improve schedule presentation

### DIFF
--- a/src/main/java/seedu/address/model/EventTime.java
+++ b/src/main/java/seedu/address/model/EventTime.java
@@ -4,6 +4,7 @@ import java.time.Duration;
 import java.time.LocalTime;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
+import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
@@ -113,6 +114,47 @@ public class EventTime implements Comparable<EventTime> {
         }
 
         return true;
+    }
+
+    /**
+     * Concatenates two EventTimes. If the two EventTime overlaps, then returns a list of one element, which
+     * is the result of the concatenation ; else, return a list of two elements.
+     *
+     * @param e1 a time
+     * @param e2 a time
+     * @return a list of either one or two elements
+     */
+    public static List<EventTime> concat(EventTime e1, EventTime e2) {
+        EventTime early = e1.compareTo(e2) > 0 ? e2 : e1;
+        EventTime late = e1.compareTo(e2) > 0 ? e1 : e2;
+
+        if (early.overlaps(late) || early.getEnd().equals(late.getStart())) {
+            return List.of(new EventTime(early.getStart(), late.getEnd()));
+        } else {
+            return List.of(early, late);
+        }
+    }
+
+    /**
+     * Appends a time to a list of EventTime. It will concatenate the incoming event time with an element in the
+     * list if they overlap or connect.
+     * @param lst a list of event time
+     * @param e the element
+     * @return a non-connecting, non-overlapping list of EventTime
+     */
+    public static List<EventTime> append(List<EventTime> lst, EventTime e) {
+        if (lst.isEmpty()) {
+            lst.add(e);
+            return lst;
+        }
+
+        Collections.sort(lst);
+
+        int last = lst.size() - 1;
+        EventTime lastEventTime = lst.remove(last);
+        lst.addAll(EventTime.concat(lastEventTime, e));
+
+        return lst;
     }
 
     /**

--- a/src/main/java/seedu/address/model/person/Schedule.java
+++ b/src/main/java/seedu/address/model/person/Schedule.java
@@ -2,6 +2,7 @@ package seedu.address.model.person;
 
 import java.time.Duration;
 import java.time.LocalTime;
+import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.NavigableSet;
 import java.util.Objects;
@@ -16,7 +17,7 @@ import seedu.address.model.person.exceptions.SchedulingException;
  * Manages the availability of the owner.
  */
 public class Schedule {
-    public static final String MESSAGE_EMPTY_SCHEDULE = "No task assigned";
+    public static final String MESSAGE_EMPTY_SCHEDULE = "On standby";
     public static final String MESSAGE_EARLIER_AVAILABLE = "An earlier time slot is available. ";
     public static final String MESSAGE_SUGGEST_TIME_FORMAT = "Suggested Time: %s ";
     public static final String MESSAGE_SCHEDULE_CONFLICT = "The duration conflicts with the existing schedule. ";
@@ -165,6 +166,7 @@ public class Schedule {
         return this.schedule
                 .subSet(EventTime.parse("0000", START_WORK_TIME), false,
                         EventTime.parse(END_WORK_TIME, "2359"), false).stream()
+                .collect(ArrayList::new, EventTime::append, ArrayList::addAll).stream()
                 .map(EventTime::to24HrString)
                 .reduce((str1, str2) -> str1 + ", " + str2)
                 .orElse(MESSAGE_EMPTY_SCHEDULE);

--- a/src/main/java/seedu/address/ui/DriverCard.java
+++ b/src/main/java/seedu/address/ui/DriverCard.java
@@ -5,7 +5,6 @@ import javafx.scene.control.Label;
 import javafx.scene.layout.HBox;
 import javafx.scene.layout.Region;
 import seedu.address.model.person.Driver;
-import seedu.address.model.person.Schedule;
 
 /**
  * An UI component that displays information of a {@code Person}.
@@ -36,11 +35,7 @@ public class DriverCard extends UiPart<Region> {
         name.setText(driver.getName().fullName);
         phone.setText("Phone: " + driver.getPhone().value);
         driverId.setText("Driver ID: #" + driver.getId());
-        if (driver.getSchedule().toString().equals(Schedule.MESSAGE_EMPTY_SCHEDULE)) {
-            availability.setText("Unavailable Time: Available all times");
-        } else {
-            availability.setText("Unavailable Time: " + driver.getSchedule());
-        }
+        availability.setText("Unavailable Time: " + driver.getSchedule());
     }
 
     @Override


### PR DESCRIPTION
Closes #129, though it doesn't directly address the problem.

This PR enhances the string representation of schedule so that two connecting time will now show as one time. For example, `1400 - 1500, 1500 - 1600, 1600 - 1700` will just show as `1400 - 1700`,